### PR TITLE
Don't add prefix in production

### DIFF
--- a/inc/GenericFilters.php
+++ b/inc/GenericFilters.php
@@ -7,11 +7,10 @@ namespace Vincit\GenericFilters;
 
 function title_prefix($title) {
   $dev = "D";
-  $production = "P";
   $staging = "S";
 
   if (\Vincit\is_prod() && is_user_logged_in()) {
-    return "[$production] $title";
+    return $title;
   } else if (\Vincit\is_dev()) {
     return "[$dev] $title";
   } elseif (!empty($_COOKIE["seravo_shadow"]) || \Vincit\is_staging()) {


### PR DESCRIPTION
I don't think having a prefix for `<title>` is good in production. Clients don't get it and it's not really necessary. It's enough to have it in staging and local dev.